### PR TITLE
Cell, another approach

### DIFF
--- a/src/cell.js
+++ b/src/cell.js
@@ -38,18 +38,6 @@ const Cell = (f, next) => {
   return c
 }
 
-// Cell.pipe = c => g => Cell.of(x => match({
-//   Stable: y => Stable.of(y),
-//   Recompute: (x) => {
-//     console.log('about to recompute', x)
-//     const [head, [_, tail]] = x
-//     return Recompute.of([
-//       head,
-//       g(Recompute.of([head, tail]))
-//     ])
-//   }
-// })(c(x)))
-
 Cell.product = c => g =>
   Cell.of(
     x => match({
@@ -73,13 +61,6 @@ const c = Cell( x => x.toUpperCase() )
 const b = Cell( x => `${x} of Cells` ).product(c)
 const a = Cell( x => `${x} world` ).product(b)
 
-// const result = a(Recompute.of(['hello', ['not expected', ['wat', ['HELLO WORLD OF CELLS', []]]]]))
-//
-// console.log(result)
-// console.log(result['@@value'])
-// console.log(result['@@value'][1]['@@value'])
-// console.log(result['@@value'][1]['@@value'][1]['@@value'])
-
 const result = a(Recompute.of(['hello', ['not expected', ['as', ['asd', ['adsf', []]]]]]))
 
 console.log(result)
@@ -87,95 +68,13 @@ console.log(result['@@value'])
 console.log(result['@@value'][1]['@@value'])
 console.log(result['@@value'][1]['@@value'][1]['@@value'])
 
-// const c = Cell( x => x.toUpperCase() )
+const fromRecomputation = x =>
+  (next => match({Stable: next, Recompute: next })(x))
+  (([head, tail]) => [head, tail != null ? fromRecomputation(tail) : null ])
 
-// console.log(b(Recompute.of(['world', ['world of Cells', []]])))
-
-// const result = a.pipe(b).pipe(c)(
-//   Recompute.of([
-//     'hello',
-//     [
-//       'hello monica',
-//       [
-//         'hello world of Cells',
-//         [
-//           '',
-//           [
-//             '',
-//             [
-//               '',
-//               []
-//             ]
-//           ]
-//         ]
-//       ]
-//     ]
-//   ])
-// )
-//
-// console.log(result)
-// console.log(result['@@value'])
-// console.log(result['@@value']['@@value'])
-
-// const tree = Recompute.of([2, Stable.of([4, Recompute.of([5, 0])])])
-//
-// const fromRecomputation = x =>
-//   (next => match({Stable: next, Recompute: next })(x))
-//   (([head, tail]) => [head, tail != null ? fromRecomputation(tail) : null ])
-//
-// console.log(tree)
-// console.log(fromRecomputation(tree))
-
-
-// const Cell = f => {
-//   const c = Arrow( either(
-//     ([head, tail]) => (
-//       result => (console.log('result', result, tail), result === tail[0]
-//         ? Right.of(tail)
-//         : Left.of([result, tail[1]]))
-//     )(Arrow(f)(head))
-//   )(
-//     Arrow(id).pipe(Left.of)
-//   ) )
-//
-//   c.pipe = g =>
-//     Cell.of(
-//       x =>
-//         either(
-//           ([head, tail]) => Left.of([
-//             head,
-//             g(
-//               Left.of(
-//                 (console.log('tail', tail), tail)
-//               )
-//             )
-//           ])
-//         )(
-//           Arrow(id).pipe(Right.of)
-//         )(c(x))
-//     )
-//
-//   return c
-// }
-//
-// Cell.of = f => Arrow(f)
-//
-// const b = Cell( x => (console.log('b', x), x + 2) )
-// const c = Cell.of( Arrow(id).product(id).sum(Arrow(id).product(id)) )
-//
-// const finalResult = a.pipe(id)(Left.of([2, [2, [5, [null]]]]))
-//
-// console.log('finalResult', finalResult)
-// console.log('finalResultInner', finalResult['@@value'])
-
-// console.log(
-//   a.pipe(b)(
-//     Left.of([
-//       2,
-//       [
-//         2,
-//         null
-//       ]
-//     ])
-//   )
-// )
+export {
+  Stable,
+  Recompute,
+  Cell,
+  fromRecomputation,
+}

--- a/src/cell.js
+++ b/src/cell.js
@@ -1,45 +1,26 @@
-import type {
-  ArrowT,
-} from 'zazen/arrow'
-
-import {
-  cond,
-} from './cond'
-
 import {
   Arrow,
 } from './arrow'
 
-export type CellT = ArrowT & {
-  last_args: [];
-  last_val: ?mixed;
-  dirty: Boolean;
+import {
+  Left,
+  Right,
+} from './either'
+
+const id = x => x
+
+const Cell = f => {
+  const c = Arrow(
+    x => (([head, tail]) => head === tail[0]
+      ? Left.of(tail)
+      : Right.of([head, tail[1]])
+    )(Arrow(f).product(Arrow(id).product(id))(x))
+  )
+
+  c.sum = g => 
 }
 
-export type CellFn = (fn: Function, child: CellT) => CellT
-const Cell: CellFn = (fn, child) => {
+const a = Cell( x => x * 2 )
+const b = Cell( x => x + 2 )
 
-  const _call = args => () => {
-    cell_fn.last_args = args
-    cell_fn.last_val = fn.apply({}, args)
-    child(cell_fn.last_val)
-    return cell_fn.last_val
-  }
-
-  const _dirty = args => () => cell_fn.last_args[0] !== args [0]
-
-  const cell_fn = Arrow((...args) => cond(
-    [ _dirty(args), _call(args) ],
-    [ true, cell_fn.last_val ]
-  ))
-
-  cell_fn.last_args = []
-  cell_fn.last_val = undefined
-  cell_fn.dirty = true
-
-  return cell_fn
-}
-
-export {
-  Cell,
-}
+console.log(a.sum(b)([2, [2, null]]))

--- a/src/cell.js
+++ b/src/cell.js
@@ -5,22 +5,177 @@ import {
 import {
   Left,
   Right,
+  either,
 } from './either'
+
+import {
+  match,
+} from './cond'
+
+import {
+  type,
+} from './type'
 
 const id = x => x
 
-const Cell = f => {
+const Stable = type('Stable')
+const Recompute = type('Recompute')
+
+const Cell = (f, next) => {
   const c = Arrow(
-    x => (([head, tail]) => head === tail[0]
-      ? Left.of(tail)
-      : Right.of([head, tail[1]])
-    )(Arrow(f).product(Arrow(id).product(id))(x))
+    match({
+      Stable: x => Arrow(id).product(Arrow(id).pipe(Stable.of))(x)[1],
+      Recompute: ([arg, [expected, tail]]) => (
+        result => result === expected
+          ? Stable.of([expected, tail])
+          : Recompute.of([
+            result,
+            next(Recompute.of([result, tail]))
+          ])
+      )(f(arg))
+    })
   )
 
-  c.sum = g => 
+  // TODO:
+  // 1. Revert the constructor
+  // 2. Use product composing from the inside out
+  c.product = g => x => match({
+    Stable: Stable.of,
+    Recompute: ([head, [_, tail]]) => Recompute.of([
+      head,
+      g(Recompute.of([head, tail])
+    ])
+  })(c(x))
+
+  // c.pipe = Cell.pipe(c)
+
+
+  return c
 }
 
-const a = Cell( x => x * 2 )
-const b = Cell( x => x + 2 )
+// Cell.pipe = c => g => Cell.of(x => match({
+//   Stable: y => Stable.of(y),
+//   Recompute: (x) => {
+//     console.log('about to recompute', x)
+//     const [head, [_, tail]] = x
+//     return Recompute.of([
+//       head,
+//       g(Recompute.of([head, tail]))
+//     ])
+//   }
+// })(c(x)))
+//
+// Cell.of = f => {
+//   const c = Arrow(f)
+//
+//   c.pipe = g => {
+//     console.log('piping', g)
+//     return Cell.pipe(c)(g)
+//   }
+//
+//   return c
+// }
 
-console.log(a.sum(b)([2, [2, null]]))
+const c = Cell( x => x.toUpperCase(), x => x)
+const b = Cell( x => `${x} of Cells`, c )
+const a = Cell( x => `${x} world`, b )
+
+const result = a(Recompute.of(['hello', ['not expected', ['wat', ['HELLO WORLD OF CELLS', []]]]]))
+
+console.log(result)
+console.log(result['@@value'])
+console.log(result['@@value'][1]['@@value'])
+console.log(result['@@value'][1]['@@value'][1]['@@value'])
+
+// const c = Cell( x => x.toUpperCase() )
+
+// console.log(b(Recompute.of(['world', ['world of Cells', []]])))
+
+// const result = a.pipe(b).pipe(c)(
+//   Recompute.of([
+//     'hello',
+//     [
+//       'hello monica',
+//       [
+//         'hello world of Cells',
+//         [
+//           '',
+//           [
+//             '',
+//             [
+//               '',
+//               []
+//             ]
+//           ]
+//         ]
+//       ]
+//     ]
+//   ])
+// )
+//
+// console.log(result)
+// console.log(result['@@value'])
+// console.log(result['@@value']['@@value'])
+
+// const tree = Recompute.of([2, Stable.of([4, Recompute.of([5, 0])])])
+//
+// const fromRecomputation = x =>
+//   (next => match({Stable: next, Recompute: next })(x))
+//   (([head, tail]) => [head, tail != null ? fromRecomputation(tail) : null ])
+//
+// console.log(tree)
+// console.log(fromRecomputation(tree))
+
+
+// const Cell = f => {
+//   const c = Arrow( either(
+//     ([head, tail]) => (
+//       result => (console.log('result', result, tail), result === tail[0]
+//         ? Right.of(tail)
+//         : Left.of([result, tail[1]]))
+//     )(Arrow(f)(head))
+//   )(
+//     Arrow(id).pipe(Left.of)
+//   ) )
+//
+//   c.pipe = g =>
+//     Cell.of(
+//       x =>
+//         either(
+//           ([head, tail]) => Left.of([
+//             head,
+//             g(
+//               Left.of(
+//                 (console.log('tail', tail), tail)
+//               )
+//             )
+//           ])
+//         )(
+//           Arrow(id).pipe(Right.of)
+//         )(c(x))
+//     )
+//
+//   return c
+// }
+//
+// Cell.of = f => Arrow(f)
+//
+// const b = Cell( x => (console.log('b', x), x + 2) )
+// const c = Cell.of( Arrow(id).product(id).sum(Arrow(id).product(id)) )
+//
+// const finalResult = a.pipe(id)(Left.of([2, [2, [5, [null]]]]))
+//
+// console.log('finalResult', finalResult)
+// console.log('finalResultInner', finalResult['@@value'])
+
+// console.log(
+//   a.pipe(b)(
+//     Left.of([
+//       2,
+//       [
+//         2,
+//         null
+//       ]
+//     ])
+//   )
+// )

--- a/src/type.js
+++ b/src/type.js
@@ -58,7 +58,7 @@ const type = (name: any): any => ({
   of: x => ({
     '@@type': name,
     '@@value': x,
-    inspect: () => `${name}(${x})`,
+    inspect: () => `${name}(${x.toString()})`,
     is: y => y['@@type'] === name
   })
 })


### PR DESCRIPTION
I’m pushing my work in progress to this branch. In a nutshell, Cell has three key differences from simple Arrows:

1. Cell implements a lifter called `Cell.of` that does not process the function to be lifted. This function should implement the signature of a Cell, `Recomputation a => a -> a`
2. `Cell` itself is a construct that takes a regular unary function and adds pattern matching on top of it so that it works with the `Recomputation` type.
3. The chaining of Cells is done via the `product` (`***`) operation, and it's done inside out. To chain `a` with `b` and `c`, the operation is `a *** (b *** c)`. Seems that product is in this case **not associative**, which means that it might violate the Arrow laws. Investigate this further.

Other than that, is working. It needs tests, type checks, verification of whether it’s following the laws or not, and implementation of the `fromRecomputation` function.